### PR TITLE
chore: cockroachdb truncate table

### DIFF
--- a/src/Query/CockroachGrammar.php
+++ b/src/Query/CockroachGrammar.php
@@ -62,6 +62,17 @@ class CockroachGrammar extends PostgresGrammar
 
         return trim($statement);
     }
+    
+    /**
+     * Compile a truncate table statement into SQL.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @return array
+     */
+    public function compileTruncate(Builder $query)
+    {
+        return ['truncate '.$this->wrapTable($query->from).' cascade' => []];
+    }
 
     /**
      * Compile a "where fulltext" clause.


### PR DESCRIPTION
CockRoachDB don't support `restart identity` in truncate