### PR TITLE
Add support for Cockroach Serverless Cluster identifier and fix dropUnique from migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,30 @@ search meaning the feature cannot be used when using this driver.
 At current if you try to create a Fulltext index using the Schema builder or try to use the `whereFulltext`
 method of the Query builder a `YlsIdeas\CockroachDb\Exceptions\FeatureNotSupportedException` exception will be thrown.
 
+### Serverless Support
+Cockroach Serverless requires you to add an `options` parameter to the connection string.
+Laravel doesn't provide this out of the box, so, it's being implemented as an extra `cluster` parameter in the database config.
+
+Sample config snippet:
+
+```php
+'crdb' => [
+    'driver' => 'crdb',
+    'url' => env('DATABASE_URL'),
+    'host' => env('DB_HOST', '127.0.0.1'),
+    'port' => env('DB_PORT', '26257'),
+    'database' => env('DB_DATABASE', 'forge'),
+    'username' => env('DB_USERNAME', 'forge'),
+    'password' => env('DB_PASSWORD', ''),
+    'charset' => 'utf8',
+    'prefix' => '',
+    'prefix_indexes' => true,
+    'schema' => 'public',
+    'sslmode' => 'prefer',
+    'cluster' => 'my-cluster-id-1234',
+]
+```
+
 ## Testing
 
 The tests try to closely follow the same functionality of the grammar provided by Laravel

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ method of the Query builder a `YlsIdeas\CockroachDb\Exceptions\FeatureNotSupport
 
 ### Serverless Support
 Cockroach Serverless requires you to add an `options` parameter to the connection string.
-Laravel doesn't provide this out of the box, so, it's being implemented as an extra `cluster` parameter in the database config.
+Laravel doesn't provide this out of the box, so, it's being implemented as an extra `cluster` parameter in the database config. Just pass the cluster identification from CockroachDB Serverless.
 
 Sample config snippet:
 
@@ -91,7 +91,7 @@ Sample config snippet:
     'prefix_indexes' => true,
     'schema' => 'public',
     'sslmode' => 'prefer',
-    'cluster' => 'my-cluster-id-1234',
+    'cluster' => env('COCKROACHDB_CLUSTER', ''),
 ]
 ```
 

--- a/src/CockroachDbConnector.php
+++ b/src/CockroachDbConnector.php
@@ -15,7 +15,7 @@ class CockroachDbConnector extends PostgresConnector implements ConnectorInterfa
     {
         $dsn = parent::getDsn($config);
 
-        if (isset($config['cluster']) && !empty($config['cluster'])) {
+        if (isset($config['cluster']) && ! empty($config['cluster'])) {
             $dsn .= ";options='--cluster={$config['cluster']}'";
         }
 

--- a/src/CockroachDbConnector.php
+++ b/src/CockroachDbConnector.php
@@ -13,10 +13,14 @@ class CockroachDbConnector extends PostgresConnector implements ConnectorInterfa
      */
     protected function getDsn(array $config)
     {
-        $dsn = parent::getDsn($config);
+        return $this->addClusterOptions(parent::getDsn($config), $config);
+    }
 
+    protected function addClusterOptions(string $dsn, array $config)
+    {
         if (isset($config['cluster']) && ! empty($config['cluster'])) {
-            $dsn .= ";options='--cluster={$config['cluster']}'";
+            $clusterNameEscaped = addslashes($config['cluster']);
+            $dsn .= ";options='--cluster={$clusterNameEscaped}'";
         }
 
         return $dsn;

--- a/src/CockroachDbConnector.php
+++ b/src/CockroachDbConnector.php
@@ -7,4 +7,18 @@ use Illuminate\Database\Connectors\PostgresConnector;
 
 class CockroachDbConnector extends PostgresConnector implements ConnectorInterface
 {
+    /**
+     * Usually the normal PostgresConnector would suffice for Cockroach,
+     * but Cockroach Serverless Clusters need an extra parameter `options`.
+     */
+    protected function getDsn(array $config)
+    {
+        $dsn = parent::getDsn($config);
+
+        if (isset($config['cluster']) && !empty($config['cluster'])) {
+            $dsn .= ";options='--cluster={$config['cluster']}'";
+        }
+
+        return $dsn;
+    }
 }

--- a/src/Schema/CockroachGrammar.php
+++ b/src/Schema/CockroachGrammar.php
@@ -34,4 +34,21 @@ class CockroachGrammar extends PostgresGrammar
     {
         return $this->compileDropIndex($blueprint, $command);
     }
+
+    /**
+     * Compile a drop unique key command.
+     * 
+     * CockroachDB doesn't support alter table for dropping unique indexes.
+     * https://github.com/cockroachdb/cockroach/issues/42840?version=v22.1
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
+     * @return string
+     */
+    public function compileDropUnique(Blueprint $blueprint, Fluent $command)
+    {
+        $index = $this->wrap($command->index);
+
+        return "drop index {$this->wrapTable($blueprint)}@{$index} cascade";
+    }
 }

--- a/src/Schema/CockroachGrammar.php
+++ b/src/Schema/CockroachGrammar.php
@@ -37,7 +37,7 @@ class CockroachGrammar extends PostgresGrammar
 
     /**
      * Compile a drop unique key command.
-     * 
+     *
      * CockroachDB doesn't support alter table for dropping unique indexes.
      * https://github.com/cockroachdb/cockroach/issues/42840?version=v22.1
      *

--- a/tests/Database/DatabaseCockroachDbConnectorTest.php
+++ b/tests/Database/DatabaseCockroachDbConnectorTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace YlsIdeas\CockroachDb\Tests\Database;
+
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use YlsIdeas\CockroachDb\CockroachDbConnector;
+
+class DatabaseCockroachDbConnectorTest extends TestCase
+{
+    public function test_dsn_params_with_cluster()
+    {
+        $connector = $this->getConnector();
+
+        $dsnConfig = $this->callProtectedOrPrivateMethod($connector, 'getDsn', [
+            [
+                'host' => 'localhost',
+                'database' => 'defaultdb',
+                'port' => '23456',
+                'cluster' => 'cluster-1234'
+            ]
+        ]);
+
+        $this->assertEquals("pgsql:host=localhost;dbname='defaultdb';port=23456;options='--cluster=cluster-1234'", $dsnConfig);
+    }
+
+    public function test_dsn_params_without_cluster()
+    {
+        $connector = $this->getConnector();
+
+        $dsnConfig = $this->callProtectedOrPrivateMethod($connector, 'getDsn', [
+            [
+                'host' => 'localhost',
+                'database' => 'defaultdb',
+                'port' => '23456',
+                'cluster' => ''
+            ]
+        ]);
+
+        $this->assertEquals("pgsql:host=localhost;dbname='defaultdb';port=23456", $dsnConfig);
+    }
+
+    /**
+     * Some methods might be protected and need to be tested. So this just exposes them using reflection.
+     */
+    protected function callProtectedOrPrivateMethod($object, string $methodName, array $arguments = [])
+    {
+        $reflectionClass = new ReflectionClass($object);
+        $reflectionMethod = $reflectionClass->getMethod($methodName);
+        $reflectionMethod->setAccessible(true);
+
+        return empty($arguments) ?
+            $reflectionMethod->invoke($object) :
+            $reflectionMethod->invokeArgs($object, $arguments);
+    }
+
+    protected function getConnector()
+    {
+        return new CockroachDbConnector();
+    }
+}

--- a/tests/Database/DatabaseCockroachDbConnectorTest.php
+++ b/tests/Database/DatabaseCockroachDbConnectorTest.php
@@ -41,8 +41,9 @@ class DatabaseCockroachDbConnectorTest extends TestCase
 
     protected function getConnector()
     {
-        return new class extends CockroachDbConnector {
-            public function exposeGetDsnMethod(array $config) {
+        return new class () extends CockroachDbConnector {
+            public function exposeGetDsnMethod(array $config)
+            {
                 return $this->getDsn($config);
             }
         };

--- a/tests/Database/DatabaseCockroachDbConnectorTest.php
+++ b/tests/Database/DatabaseCockroachDbConnectorTest.php
@@ -21,7 +21,7 @@ class DatabaseCockroachDbConnectorTest extends TestCase
             ],
         ]);
 
-        $this->assertEquals("pgsql:host=localhost;dbname='defaultdb';port=23456;options='--cluster=cluster-1234'", $dsnConfig);
+        $this->assertStringContainsString("options='--cluster=cluster-1234'", $dsnConfig);
     }
 
     public function test_dsn_params_without_cluster()
@@ -37,7 +37,7 @@ class DatabaseCockroachDbConnectorTest extends TestCase
             ],
         ]);
 
-        $this->assertEquals("pgsql:host=localhost;dbname='defaultdb';port=23456", $dsnConfig);
+        $this->assertStringNotContainsString("options=", $dsnConfig);
     }
 
     /**

--- a/tests/Database/DatabaseCockroachDbConnectorTest.php
+++ b/tests/Database/DatabaseCockroachDbConnectorTest.php
@@ -17,8 +17,8 @@ class DatabaseCockroachDbConnectorTest extends TestCase
                 'host' => 'localhost',
                 'database' => 'defaultdb',
                 'port' => '23456',
-                'cluster' => 'cluster-1234'
-            ]
+                'cluster' => 'cluster-1234',
+            ],
         ]);
 
         $this->assertEquals("pgsql:host=localhost;dbname='defaultdb';port=23456;options='--cluster=cluster-1234'", $dsnConfig);
@@ -33,8 +33,8 @@ class DatabaseCockroachDbConnectorTest extends TestCase
                 'host' => 'localhost',
                 'database' => 'defaultdb',
                 'port' => '23456',
-                'cluster' => ''
-            ]
+                'cluster' => '',
+            ],
         ]);
 
         $this->assertEquals("pgsql:host=localhost;dbname='defaultdb';port=23456", $dsnConfig);

--- a/tests/Database/DatabaseCockroachDbSchemaGrammarTest.php
+++ b/tests/Database/DatabaseCockroachDbSchemaGrammarTest.php
@@ -140,7 +140,7 @@ class DatabaseCockroachDbSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" drop constraint "foo"', $statements[0]);
+        $this->assertSame('drop index "users"@"foo" cascade', $statements[0]);
     }
 
     public function test_drop_index()


### PR DESCRIPTION
Previously we could add the cluster identifier as part of the database name. Laravel would work out of the box, but as of today (2022-09-22), it looks like they (Cockroach Labs) changed something on their side and made the `artisan migrate` command fails, as it was querying the migrations table in the database with the cluster identifier in its name.

So, I changed the Database Connector to add the missing `options` parameter to the DSN when the `cluster` parameter is present in the config.

This PR also fixes the `dropUnique` from the migrations, as CockroachDB doesn't support an `alter table drop` for a unique index ( See https://github.com/cockroachdb/cockroach/issues/42840?version=v22.1 )