### PR TITLE
Drop unique indexes fixes

### DIFF
--- a/src/Schema/CockroachGrammar.php
+++ b/src/Schema/CockroachGrammar.php
@@ -34,4 +34,21 @@ class CockroachGrammar extends PostgresGrammar
     {
         return $this->compileDropIndex($blueprint, $command);
     }
+
+    /**
+     * Compile a drop unique key command.
+     * 
+     * CockroachDB doesn't support alter table for dropping unique indexes.
+     * https://github.com/cockroachdb/cockroach/issues/42840?version=v22.1
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
+     * @return string
+     */
+    public function compileDropUnique(Blueprint $blueprint, Fluent $command)
+    {
+        $index = $this->wrap($command->index);
+
+        return "drop index {$this->wrapTable($blueprint)}@{$index} cascade";
+    }
 }

--- a/src/Schema/CockroachGrammar.php
+++ b/src/Schema/CockroachGrammar.php
@@ -37,7 +37,7 @@ class CockroachGrammar extends PostgresGrammar
 
     /**
      * Compile a drop unique key command.
-     * 
+     *
      * CockroachDB doesn't support alter table for dropping unique indexes.
      * https://github.com/cockroachdb/cockroach/issues/42840?version=v22.1
      *

--- a/tests/Database/DatabaseCockroachDbSchemaGrammarTest.php
+++ b/tests/Database/DatabaseCockroachDbSchemaGrammarTest.php
@@ -140,7 +140,7 @@ class DatabaseCockroachDbSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" drop constraint "foo"', $statements[0]);
+        $this->assertSame('drop index "users"@"foo" cascade', $statements[0]);
     }
 
     public function test_drop_index()


### PR DESCRIPTION
This fixes the drop of unique indexes as CockroachDB doesn't support it with the usual alter table

See https://github.com/cockroachdb/cockroach/issues/42840