### PR TITLE
fix: Any artisan command that drops tables erroring with unknown function: pg_total_relation_size()

### DIFF
--- a/src/Schema/CockroachGrammar.php
+++ b/src/Schema/CockroachGrammar.php
@@ -21,8 +21,8 @@ class CockroachGrammar extends PostgresGrammar
     public function compileTables()
     {
         return 'select c.relname as name, n.nspname as schema, -1 as size, '
-            . "obj_description(c.oid, 'pg_class') as comment from pg_class c, pg_namespace n "
-            . "where c.relkind = 'r' and n.oid = c.relnamespace "
+            . 'obj_description(c.oid, \'pg_class\') as comment from pg_class c, pg_namespace n '
+            . 'where c.relkind = \'r\' and n.oid = c.relnamespace '
             . 'order by c.relname';
     }
 

--- a/src/Schema/CockroachGrammar.php
+++ b/src/Schema/CockroachGrammar.php
@@ -10,6 +10,23 @@ use YlsIdeas\CockroachDb\Exceptions\FeatureNotSupportedException;
 class CockroachGrammar extends PostgresGrammar
 {
     /**
+     * Compile the query to determine the tables.
+     *
+     * CockroachDB doesn't yet support pg_total_relation_size()
+     * https://github.com/cockroachdb/cockroach/issues/20712
+     * https://github.com/cockroachdb/cockroach/pull/59604
+     *
+     * @return string
+     */
+    public function compileTables()
+    {
+        return 'select c.relname as name, n.nspname as schema, 0 as size, '
+            . "obj_description(c.oid, 'pg_class') as comment from pg_class c, pg_namespace n "
+            . "where c.relkind = 'r' and n.oid = c.relnamespace "
+            . 'order by c.relname';
+    }
+
+    /**
      * Compile a fulltext index key command.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint

--- a/src/Schema/CockroachGrammar.php
+++ b/src/Schema/CockroachGrammar.php
@@ -20,7 +20,7 @@ class CockroachGrammar extends PostgresGrammar
      */
     public function compileTables()
     {
-        return 'select c.relname as name, n.nspname as schema, 0 as size, '
+        return 'select c.relname as name, n.nspname as schema, -1 as size, '
             . "obj_description(c.oid, 'pg_class') as comment from pg_class c, pg_namespace n "
             . "where c.relkind = 'r' and n.oid = c.relnamespace "
             . 'order by c.relname';


### PR DESCRIPTION
As of Laravel v10.34.0, any Artisan command that drops tables, errors with `unknown function: pg_total_relation_size()`.

At least these three commands are affected:
- `db:wipe`
- `migrate:fresh`
- `migrate:refresh`

This is due to PR [#49020](https://github.com/laravel/framework/pull/49020) that changed how the list of tables is loaded.

As far as I can tell, CRDB doesn't support getting table file size via SQL. There is an open issue [here](https://github.com/cockroachdb/cockroach/issues/20712) and corresponding [PR](https://github.com/cockroachdb/cockroach/pull/59604) to add `pg_total_relation_size()`.

This PR overrides `compileTables()` hardcoding the table size to `-1`. `-1 as size` instead of `pg_total_relation_size(c.oid) as size`.